### PR TITLE
fix: fix android fast refresh crash

### DIFF
--- a/android/src/main/cpp/AudioEngine.cpp
+++ b/android/src/main/cpp/AudioEngine.cpp
@@ -41,6 +41,13 @@ void AudioEngine::openAudioStream() {
     }
 }
 
+void AudioEngine::closeAudioStream() {
+    oboe::Result result = mAudioStream->close();
+    if(result != oboe::Result::OK) {
+        LOGE("Failed to start stream, Error: %s", oboe::convertToText(result));
+    }
+}
+
 oboe::DataCallbackResult
 AudioEngine::onAudioReady(oboe::AudioStream *oboeStream, void *audioData, int32_t numFrames) {
     memset(audioData, 0, sizeof(float) * numFrames * mDesiredChannelCount);
@@ -107,3 +114,4 @@ void AudioEngine::unloadSound(const std::string &playerId) {
         LOGE("Player with identifier: %s not found", playerId.c_str());
     }
 }
+

--- a/android/src/main/cpp/AudioEngine.h
+++ b/android/src/main/cpp/AudioEngine.h
@@ -17,6 +17,7 @@ class AudioEngine : public oboe::AudioStreamDataCallback{
 public:
     explicit AudioEngine(double sampleRate, double channelCount);
     void openAudioStream();
+    void closeAudioStream();
     std::optional<std::string> loadSound(int fd, int offset, int length);
     void unloadSound(const std::string &playerId);
     void playSounds(const std::vector<std::pair<std::string, bool>>&);

--- a/android/src/main/cpp/native-lib.cpp
+++ b/android/src/main/cpp/native-lib.cpp
@@ -81,6 +81,11 @@ Java_com_audioplayback_AudioPlaybackModule_openAudioStreamNative(JNIEnv *env, jo
 }
 
 JNIEXPORT void JNICALL
+Java_com_audioplayback_AudioPlaybackModule_closeAudioStreamNative(JNIEnv *env, jobject thiz) {
+    audioEngine->closeAudioStream();
+}
+
+JNIEXPORT void JNICALL
 Java_com_audioplayback_AudioPlaybackModule_unloadSoundNative(JNIEnv *env, jobject instance, jstring playerId) {
     audioEngine->unloadSound(jstringToStdString(env, playerId));
 }

--- a/android/src/main/java/com/audioplayback/AudioPlaybackModule.kt
+++ b/android/src/main/java/com/audioplayback/AudioPlaybackModule.kt
@@ -134,8 +134,14 @@ class AudioPlaybackModule internal constructor(context: ReactApplicationContext)
     return Pair(strings, bools)
   }
 
+  override fun invalidate() {
+    super.invalidate()
+    closeAudioStreamNative()
+  }
+
   private external fun setupAudioStreamNative(sampleRate: Double, channelCount: Double)
   private external fun openAudioStreamNative()
+  private external fun closeAudioStreamNative()
   private external fun playSoundsNative(ids: Array<String>, values: BooleanArray)
   private external fun loopSoundsNative(ids: Array<String>, values: BooleanArray)
   private external fun seekSoundsToNative(ids: Array<String>, values: DoubleArray)


### PR DESCRIPTION
## Summary
Fast refreshing android while stream is open crashes the app.

## Solution
Close the audio stream before the module is destroyed