### PR TITLE
fix: fix a race condition when downloading files

### DIFF
--- a/android/src/main/java/com/audioplayback/models/FileDescriptorProps.kt
+++ b/android/src/main/java/com/audioplayback/models/FileDescriptorProps.kt
@@ -6,6 +6,7 @@ import android.util.Log
 import java.io.File
 import java.net.HttpURLConnection
 import java.net.URL
+import java.util.UUID
 
 class FileDescriptorProps(val id: Int, val length: Int, val offset: Int) {
   companion object {
@@ -28,7 +29,7 @@ class FileDescriptorProps(val id: Int, val length: Int, val offset: Int) {
         // Save the downloaded file to a temporary file
         val inputStream = connection.inputStream
         val tempFile =
-          File(context.cacheDir, "tempSoundFile")
+          File(context.cacheDir, "tempSoundFile_${UUID.randomUUID()}")
         tempFile.outputStream().use { outputStream ->
           inputStream.copyTo(outputStream)
         }


### PR DESCRIPTION
## Summary
When download a remote file(local file but in dev mode from metro), the files are being downloaded to the same file which when loading files at the same time could lead to one sound writing over the other and getting unexpected behaviour. 

To fix it, I am downloading the sounds to unique file names