### PR TITLE
fix: remove unneeded format import

### DIFF
--- a/android/src/main/cpp/audio/NDKExtractor.cpp
+++ b/android/src/main/cpp/audio/NDKExtractor.cpp
@@ -18,7 +18,6 @@
 
 #include <cstring>
 #include <sstream>
-#include <format>
 
 #include <media/NdkMediaExtractor.h>
 #include <utils/logging.h>


### PR DESCRIPTION
Removes the format header import because:
1. it is not needed
2. causing issues, check #21 